### PR TITLE
Update revision and configure HTTP header size limit

### DIFF
--- a/platine-management-api/src/main/resources/application.properties
+++ b/platine-management-api/src/main/resources/application.properties
@@ -97,4 +97,4 @@ fr.insee.datacollectionmanagement.api.xform2.url=http://localhost:8090/xform2
 fr.insee.datacollectionmanagement.public.urls=/swagger-ui/**,/swagger-ui.html,/v3/api-docs/**,/csrf, /,/webjars/**,/swagger-resources/**,/environnement,/healthcheck,/actuator/**
 
 
-server.max-http-request-header-size=16384
+server.max-http-header-size=16384

--- a/platine-management-api/src/main/resources/application.properties
+++ b/platine-management-api/src/main/resources/application.properties
@@ -95,3 +95,6 @@ fr.insee.datacollectionmanagement.api.questioning.sensitive.api.url=http://local
 fr.insee.datacollectionmanagement.api.xform1.url=http://localhost:8090/xform1
 fr.insee.datacollectionmanagement.api.xform2.url=http://localhost:8090/xform2
 fr.insee.datacollectionmanagement.public.urls=/swagger-ui/**,/swagger-ui.html,/v3/api-docs/**,/csrf, /,/webjars/**,/swagger-resources/**,/environnement,/healthcheck,/actuator/**
+
+
+server.max-http-request-header-size=16384

--- a/platine-management-api/src/main/resources/application.properties
+++ b/platine-management-api/src/main/resources/application.properties
@@ -97,4 +97,5 @@ fr.insee.datacollectionmanagement.api.xform2.url=http://localhost:8090/xform2
 fr.insee.datacollectionmanagement.public.urls=/swagger-ui/**,/swagger-ui.html,/v3/api-docs/**,/csrf, /,/webjars/**,/swagger-resources/**,/environnement,/healthcheck,/actuator/**
 
 
-server.max-http-header-size=16384
+## Server connections configuration
+server.max-http-request-header-size=128KB

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <module>platine-management-api</module>
     </modules>
     <properties>
-		<revision>3.16.2</revision>
+		<revision>3.16.3</revision>
 		<changelist></changelist>
 		<java.version>21</java.version>
 		<maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
Bumped the project revision from 3.16.2 to 3.16.3 in `pom.xml`. Added a new property to set `server.max-http-request-header-size` to 16384 in `application.properties` for handling larger HTTP headers.