### PR TITLE
Fix bogue suite dev mails divers

### DIFF
--- a/platine-management-shared/src/main/java/fr/insee/survey/datacollectionmanagement/questioning/enums/TypeCommunicationEvent.java
+++ b/platine-management-shared/src/main/java/fr/insee/survey/datacollectionmanagement/questioning/enums/TypeCommunicationEvent.java
@@ -5,6 +5,7 @@ public enum TypeCommunicationEvent {
     MAIL_OUVERTURE,
     COURRIER_RELANCE,
     MAIL_RELANCE,
+    MAIL_DIVERS,
     COURRIER_MED,
     COURRIER_MEDAR,
     COURRIER_CNR,

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <module>platine-management-api</module>
     </modules>
     <properties>
-		<revision>4.5.1</revision>
+		<revision>4.5.2</revision>
 		<changelist></changelist>
 		<java.version>21</java.version>
 		<maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
La colonne questioning_communication.type peut maintenant contenir la valeur `MAIL_DIVERS` : ça entraîne un bogue tel que décrit là : https://tuleap.insee.fr/plugins/tracker/?aid=12271#followup_154041